### PR TITLE
WIP adding datasets

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,3 +6,4 @@ version = "0.1.0"
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/SimpleSDMDataSources.jl
+++ b/src/SimpleSDMDataSources.jl
@@ -10,14 +10,18 @@ abstract type SDMDataSource end
 abstract type SDMDataSet end
 
 # List of data sources
-struct EarthEnv <: SDMDataSource end
+
+struct WorldClim{X} <: SDMDataSource end
 struct CHELSA <: SDMDataSource end
+struct EarthEnv <: SDMDataSource end
+
+export WorldClim, CHELSA, EarthEnv, AWAP, ALWB
+
+# List of data sets
 struct Weather <: SDMDataSet end
 struct BioClim <: SDMDataSet end
 struct LandCover <: SDMDataSet end
 struct HabitatHeterogeneity <: SDMDataSet end
-
-export WorldClim, CHELSA, EarthEnv, AWAP, ALWB
 
 export BioClim, Weather, LandCover, HabitatHeterogeneity
 

--- a/src/SimpleSDMDataSources.jl
+++ b/src/SimpleSDMDataSources.jl
@@ -1,26 +1,31 @@
 module SimpleSDMDataSources
 
 # Load the dependencies for this package
-using HTTP
-using ZipFile
+using HTTP,
+      ZipFile,
+      Dates
 
 # Abstract types for the download
 abstract type SDMDataSource end
 abstract type SDMDataSet end
 
 # List of data sources
-struct WorldClim <: SDMDataSource end
-struct CHELSA <: SDMDataSource end
 struct EarthEnv <: SDMDataSource end
-
-export WorldClim, CHELSA, EarthEnv
-
-# List of data sets
+struct CHELSA <: SDMDataSource end
+struct Weather <: SDMDataSet end
 struct BioClim <: SDMDataSet end
 struct LandCover <: SDMDataSet end
 struct HabitatHeterogeneity <: SDMDataSet end
 
-export BioClim, LandCover, HabitatHeterogeneity
+export WorldClim, CHELSA, EarthEnv, AWAP, ALWB
+
+export BioClim, Weather, LandCover, HabitatHeterogeneity
+
+# Using types to specify layers makes sense in some contexts
+# These are exported for AWAP, but are experimental
+export Temperature, VapourPressure, Solar, Rainfall, H09, H15, MinAve, MaxAve
+
+export download_raster, rasterpath
 
 # Create a path for the various assets
 include("assets_path.jl")
@@ -29,10 +34,14 @@ include("assets_path.jl")
 include("download.jl")
 
 # Download raster data
+include("worldclim/shared.jl")
 include("worldclim/bioclim.jl")
+include("worldclim/weather.jl")
 include("chelsa/bioclim.jl")
 include("earthenv/landcover.jl")
 include("earthenv/habitatheterogeneity.jl")
+include("awap/awap.jl")
+include("alwb/alwb.jl")
 
 export download_raster
 

--- a/src/alwb/alwb.jl
+++ b/src/alwb/alwb.jl
@@ -1,0 +1,128 @@
+# Types
+
+#= ALWB has a lot of data sources - with varying
+degrees of nesting. Here wee use types to navigate
+and structure the nesting, instead of just using 
+symbols.
+=#
+
+const ALWB_URL = "http://www.bom.gov.au/jsp/awra/thredds/fileServer/AWRACMS"
+
+abstract type DataMode end
+
+struct Values <: DataMode end
+struct Deciles <: DataMode end
+
+const ALWBperiod = Union{Day,Month,Year}
+
+struct ALWB{M<:DataMode,D<:ALWBperiod} <: SDMDataSource end
+
+struct ReferenceCrop end
+
+struct SoilMoisture{X} end
+# http://www.bom.gov.au/jsp/awra/thredds/fileServer/AWRACMS/values/day/s0_pct_2017.nc
+struct Upper end
+_pathsegment(::SoilMoisture{Upper}) = "s0_pct"
+# http://www.bom.gov.au/jsp/awra/thredds/fileServer/AWRACMS/values/day/ss_pct_2017.nc
+struct Lower end
+_pathsegment(::SoilMoisture{Lower}) = "ss_pct"
+# http://www.bom.gov.au/jsp/awra/thredds/fileServer/AWRACMS/values/day/sd_pct_2017.nc
+struct Deep end
+_pathsegment(::SoilMoisture{Deep}) = "sd_pct"
+# http://www.bom.gov.au/jsp/awra/thredds/fileServer/AWRACMS/values/day/sm_pct_2017.nc
+struct RootZone end 
+_pathsegment(::SoilMoisture{RootZone}) = "sm_pct"
+
+# http://www.bom.gov.au/jsp/awra/thredds/fileServer/AWRACMS/values/day/rain_day_2017.nc
+struct Precipiation end
+_pathsegment(::Precipiation) = "rain_day"
+# http://www.bom.gov.au/jsp/awra/thredds/fileServer/AWRACMS/values/day/qtot_2017.nc
+struct Runoff end
+_pathsegment(::Runoff) = "qtot"
+
+struct Evapotrans{X} end
+# http://www.bom.gov.au/jsp/awra/thredds/fileServer/AWRACMS/values/day/etot_2017.nc
+struct Actual end
+_pathsegment(::Evapotrans{Actual}) = "etot"
+
+struct Potential{X} end
+# http://www.bom.gov.au/jsp/awra/thredds/fileServer/AWRACMS/values/day/e0_2017.nc
+struct Landscape end
+_pathsegment(::Evapotrans{Potential{Landscape}}) = "e0"
+# http://www.bom.gov.au/jsp/awra/thredds/fileServer/AWRACMS/values/day/ma_wet_2017.nc
+struct Areal end
+_pathsegment(::Evapotrans{Potential{Areal}}) = "ma_wet"
+# http://www.bom.gov.au/jsp/awra/thredds/fileServer/AWRACMS/values/day/pen_pet_2017.nc
+struct SyntheticPan end
+_pathsegment(::Evapotrans{Potential{SyntheticPan}}) = "pen_pet"
+
+struct RefCrop{X} end
+# http://www.bom.gov.au/jsp/awra/thredds/fileServer/AWRACMS/values/day/fao_pet_2017.nc
+struct Short end
+_pathsegment(::RefCrop{Short}) = "fao_pet"
+# http://www.bom.gov.au/jsp/awra/thredds/fileServer/AWRACMS/values/day/asce_pet_2017.nc
+struct Tall end
+_pathsegment(::RefCrop{Tall}) = "asce_pet"
+
+# http://www.bom.gov.au/jsp/awra/thredds/fileServer/AWRACMS/values/day/etot_2017.nc
+
+struct Evaporation{X} end
+# http://www.bom.gov.au/jsp/awra/thredds/fileServer/AWRACMS/values/day/msl_wet_2017.nc
+struct OpenWater end
+_pathsegment(::Evaporation{OpenWater}) = "msl_wet"
+#
+# http://www.bom.gov.au/jsp/awra/thredds/fileServer/AWRACMS/values/day/dd_2017.nc
+struct DeepDrainage end
+_pathsegment(::DeepDrainage) = "dd"
+
+
+
+# Interface methods
+
+rasterpath(::Type{<:ALWB{M,P}}) where {M,P} =
+    joinpath(rasterpath(), "ALWB", map(_pathsegment, (M, P))...)
+rasterpath(T::Type{<:ALWB}, layer) = joinpath(rasterpath(T), _pathsegment(layer))
+rasterpath(T::Type{<:ALWB}, layer, date) =
+    joinpath(rasterpath(T, layer), rastername(T, layer, date))
+
+rastername(T::Type{<:ALWB{M,P}}, layer, date) where {M,P}=
+    joinpath(_pathsegment(layer), _pathsegment(P, date), ".nc")
+
+rasterurl(T::Type{<:ALWB{M,P}}, layer, date) where {M,P} =
+    joinpath(ALWB_URL, _pathsegment(layer), rastername(T, layer, date))
+
+# Days and months are in whole-year files
+_pathsegment(P::Type{<:Union{Day,Month}}, date) = string(year(date))
+# The years are all in one file
+_pathsegment(P::Type{Year}, date) = ""
+
+# download_raster(::Type{<:ALWB}; dates, kwargs...) = download_raster(T, AWAP_ALL; dates, kwargs...)
+function download_raster(T::Type{<:ALWB{M,P}}, layer::Type; dates) where {M,P}
+    dates = _date_sequence(dates, P(1))
+    mkpath(rasterpath(T, layer))
+    raster_paths = String[]
+    for d in dates
+        s = _pathsegments(T)
+        url = rasterurl(T, layer, d)
+        raster_path = rasterpath(T, layer, d)
+        _maybe_download(rasterurl(T, layer, d), raster_path)
+        push!(raster_paths, raster_path)
+    end
+    raster_paths
+end
+
+
+# Utilitiy methods
+
+_date_sequence(dates::AbstractArray, step) = dates
+_date_sequence(dates::Tuple, step) = first(dates):step:last(dates)
+
+_date2string(t, date) = Dates.format(date, _dateformat(t))
+_string2date(t, d::AbstractString) = Date(d, _dateformat(t))
+
+
+_pathsegment(::Values) = "values"
+_pathsegments(::Deciles) = "deciles"
+_pathsegment(::Day) = "day"
+_pathsegment(::Month) = "month"
+_pathsegment(::Year) = "year"

--- a/src/assets_path.jl
+++ b/src/assets_path.jl
@@ -1,19 +1,35 @@
-function _raster_assets_folder()
-    project_path = dirname(something(Base.current_project(pwd()), Base.load_path_expand(LOAD_PATH[2])))
-    assets_folder = joinpath(project_path, "assets", "general")
-    ispath(assets_folder) || mkpath(assets_folder)
-    return assets_folder
+# Allow this to be set manually
+function rasterpath() 
+    if haskey(ENV, "ECODATASOURCES_PATH") && isdir(ENV["ECODATASOURCES_PATH"])
+        ENV["ECODATASOURCES_PATH"]
+    else
+        error("You must set `ENV[\"ECODATASOURCES_PATH\"]` to a path in your system")
+    end
 end
 
-function _raster_assets_folder(::Type{TS}, ::Type{TD}) where {TS <: SDMDataSource, TD <: SDMDataSet}
-    project_path = dirname(something(Base.current_project(pwd()), Base.load_path_expand(LOAD_PATH[2])))
-    assets_folder = joinpath(project_path, "assets", string(TS), string(TD))
-    ispath(assets_folder) || mkpath(assets_folder)
-    return assets_folder
-end
+# function _raster_assets_folder()
+#     project_path = dirname(something(Base.current_project(pwd()), Base.load_path_expand(LOAD_PATH[2])))
+#     assets_folder = joinpath(project_path, "assets", "general")
+#     ispath(assets_folder) || mkpath(assets_folder)
+#     return assets_folder
+# end
+
+# The folder structure could be more or less deeply nested than this
+
+# function _raster_assets_folder(::Type{TS}, ::Type{TD}) where {TS <: SDMDataSource, TD <: SDMDataSet}
+#     project_path = dirname(something(Base.current_project(pwd()), Base.load_path_expand(LOAD_PATH[2])))
+#     assets_folder = joinpath(project_path, "assets", string(TS), string(TD))
+#     ispath(assets_folder) || mkpath(assets_folder)
+#     return assets_folder
+# end
 
 function cleanup_assets()
-    ispath(_raster_assets_folder()) && rm(_raster_assets_folder(); recursive=false)
+    # May need an "are you sure"? - this could be a lot of GB of data to lose
+    ispath(rasterpath()) && rm(rasterpath())
+end
+
+function cleanup_assets(T::Type)
+    ispath(rasterpath(T)) && rm(rasterpath(T))
 end
 
 function cleanup_assets(::Type{TS}, ::Type{TD}) where {TS <: SDMDataSource, TD <: SDMDataSet}

--- a/src/awap/awap.jl
+++ b/src/awap/awap.jl
@@ -1,0 +1,84 @@
+
+# Types
+
+struct AWAP <: SDMDataSource end
+
+struct Temperature{X} end
+struct VapourPressure{X} end
+struct Solar{X} end
+struct Rainfall{X} end
+
+struct H09 end
+struct H15 end
+struct MinAve end
+struct MaxAve end
+
+const AWAP_LAYERS = (Solar, Rainfall, VapourPressure{H09}, VapourPressure{H15}, Temperature{MinAve})
+const AWAP_DATEFORMAT = DateFormat("yyyymmdd")
+
+
+
+# Interface methods
+
+download_raster(T::Type{AWAP}, layers::Tuple; kwargs...) =
+    # What to return here? A NamedTuple of Vectors of paths?
+    (map(l -> download_raster(T, l; kwargs...), layers); nothing)
+download_raster(::Type{AWAP}; dates, kwargs...) =
+    download_raster(AWAP, AWAP_LAYERS; dates, kwargs...)
+download_raster(T::Type{AWAP}, t; kwargs...) =
+    download_raster(T, typeof(t); kwargs...)
+function download_raster(T::Type{AWAP}, layer::Type; dates)
+    dates = _date_sequence(dates, Day(1))
+    mkpath(rasterpath(T, layer))
+    for d in dates
+        raster_path = rasterpath(T, layer, d)
+        println(raster_path)
+        if !isfile(raster_path)
+            zip_path = zippath(T, layer, d)
+            println(zip_path)
+            _maybe_download(zipurl(T, layer, d), zip_path)
+            run(`uncompress $zip_path -f`)
+        end
+    end
+    # What to return here? A vector of paths?
+    nothing
+end
+
+rasterpath(T::Type{AWAP}) = joinpath(rasterpath(), "AWAP")
+rasterpath(T::Type{AWAP}, layer) = joinpath(rasterpath(T), _pathsegments(layer)[1:2]...)
+rasterpath(T::Type{AWAP}, layer, date::Dates.AbstractTime) =
+    joinpath(rasterpath(T, layer), rastername(T, layer, date))
+
+rastername(T::Type{AWAP}, layer, date::Dates.AbstractTime) =
+    joinpath(_date2string(T, date) * ".grid")
+
+function zipurl(T::Type{AWAP}, layer, date)
+    s = _pathsegments(layer)
+    d = _date2string(T, date)
+    # The actual zip name has the date twice, which is weird.
+    # So we download in to a different name as there no output
+    # name flages for `uncompress`. It's ancient.
+    joinpath("http://www.bom.gov.au/web03/ncc/www/awap", s..., "grid/0.05/history/nat/$d$d.grid.Z")
+end
+
+zipname(T::Type{AWAP}, layer, date) = _date2string(T, date) * ".grid.Z"
+
+zippath(T::Type{AWAP}, layer, date) = joinpath(rasterpath(T, layer), zipname(T, layer, date))
+
+
+# Utilitiy methods
+
+_dateformat(::Type{AWAP}) = DateFormat("yyyymmdd")
+
+_pathsegments(::Type{<:Solar}) = "solar", "solarave", "daily"
+_pathsegments(::Type{<:Rainfall}) = "rainfall", "totals", "daily"
+_pathsegments(::Type{VapourPressure{H09}}) = "vprp", "vprph09", "daily"
+_pathsegments(::Type{VapourPressure{H15}}) = "vprp", "vprph15", "daily"
+_pathsegments(::Type{Temperature{MinAve}}) = "temperature", "minave", "daily"
+_pathsegments(::Type{Temperature{MaxAve}}) = "temperature", "maxave", "daily"
+
+#=
+Add ndvi monthly?
+ndvi,ndviave,month
+=#
+

--- a/src/chelsa/bioclim.jl
+++ b/src/chelsa/bioclim.jl
@@ -6,5 +6,5 @@ function download_raster(::Type{CHELSA}, ::Type{BioClim}; layer::Integer=1)
     url_root = "ftp://envidatrepo.wsl.ch/uploads/chelsa/chelsa_V1/climatologies/bio/"
 
     filepath = joinpath(path, filename)
-    return SimpleSDMDataSources._download_file(filepath, url_root * filename)
+    return _maybe_download(filepath, url_root * filename)
 end

--- a/src/download.jl
+++ b/src/download.jl
@@ -1,9 +1,7 @@
-function _download_file(filename, url)
-    if !isfile(filename)
-        layerrequest = HTTP.request("GET", url)
-        open(filename, "w") do layerfile
-            write(layerfile, String(layerrequest.body))
-        end
+function _maybe_download(url, filepath)
+    if !isfile(filepath)
+        mkpath(dirname(filepath))
+        HTTP.download(url, filepath)
     end
-    return filename
+    filepath
 end

--- a/src/earthenv/habitatheterogeneity.jl
+++ b/src/earthenv/habitatheterogeneity.jl
@@ -22,5 +22,5 @@ function download_raster(::Type{EarthEnv}, ::Type{HabitatHeterogeneity}; layer::
     stem = "$(layer)_01_05_$(string(resolution))km_$(precision).tif"
     filename = "$(layer)_$(resolution)km.tif"
 
-    return SimpleSDMDataSources._download_file(joinpath(path, filename), root * stem)
+    return _maybe_download(root * stem, joinpath(path, filename))
 end

--- a/src/earthenv/landcover.jl
+++ b/src/earthenv/landcover.jl
@@ -9,6 +9,6 @@ function download_raster(::Type{EarthEnv}, ::Type{LandCover}; layer::Integer=1, 
     filetype = discover ? "complete" : "partial"
     filename = "landcover_$(filetype)_$(layer).tif"
 
-    return _download_file(joinpath(path, filename), root * stem)
+    return _maybe_download(root * stem, joinpath(path, filename))
 
 end

--- a/src/worldclim/bioclim.jl
+++ b/src/worldclim/bioclim.jl
@@ -1,5 +1,3 @@
-struct BioClim <: SDMDataSet end
-
 const resolutions = Dict(2.5 => "2.5", 5.0 => "5", 10.0 => "10")
 
 function download_raster(T::Type{WorldClim{BioClim}}; layer::Integer=1, resolution::AbstractFloat=10.0)

--- a/src/worldclim/shared.jl
+++ b/src/worldclim/shared.jl
@@ -1,0 +1,12 @@
+
+struct WorldClim{X} <: SDMDataSource end
+
+const WORLDCLIM_URL = "https://biogeo.ucdavis.edu/data/worldclim/v2.1"
+
+rasterpath(::Type{WorldClim{T}}) where T = 
+    joinpath(rasterpath(), "WorldClim", string(nameof(T)))
+rasterpath(T::Type{<:WorldClim}, layer) = joinpath(rasterpath(T), string(layer))
+rasterpath(T::Type{<:WorldClim}, layer, x) =
+    joinpath(rasterpath(T, layer), rastername(T, layer, x))
+
+file_to_read(raster_name, zf) = first(filter(f -> f.name == raster_name, zf.files))

--- a/src/worldclim/shared.jl
+++ b/src/worldclim/shared.jl
@@ -1,6 +1,4 @@
 
-struct WorldClim{X} <: SDMDataSource end
-
 const WORLDCLIM_URL = "https://biogeo.ucdavis.edu/data/worldclim/v2.1"
 
 rasterpath(::Type{WorldClim{T}}) where T = 

--- a/src/worldclim/weather.jl
+++ b/src/worldclim/weather.jl
@@ -1,0 +1,53 @@
+const WEATHER_DECADES = Dict(Date(1960) => "1960-1969",
+                             Date(1970) => "1970-1979",
+                             Date(1980) => "1980-1989",
+                             Date(1990) => "1990-1999",
+                             Date(2000) => "2000-2009",
+                             Date(2010) => "2010-2018")
+
+const WEATHER_LAYERS = (:tmin, :tmax, :prec)
+
+function download_raster(T::Type{WorldClim{Weather}}; dates, layers=WEATHER_LAYERS)
+    all(l -> l in WEATHER_LAYERS, layers) || throw(ArgumentError("Layers must be from $WEATHER_LAYERS"))
+    dates = _date_sequence(dates, Month(1))
+    decadestart = Date.(1960:10:2020)
+
+    for layer in layers
+        for i in eachindex(decadestart[1:end-1])
+            # At least one date is in the decade
+            any(d -> d >= decadestart[i] && d < decadestart[i+1], dates) || continue
+            zip_path = zippath(T, layer, decadestart[i])
+            _maybe_download(zipurl(T, layer, decadestart[i]), zip_path)
+            zf = ZipFile.Reader(zip_path)
+            for d in dates
+                raster_path = rasterpath(T, layer, d)
+                mkpath(dirname(raster_path))
+                if !isfile(raster_path)
+                    raster_name = rastername(T, layer, d)
+                    println("Writing $(raster_path)...")
+                    write(raster_path, read(file_to_read(raster_name, zf)))
+                end
+            end
+            close(zf)
+        end
+    end
+end
+
+rastername(T::Type{<:WorldClim{Weather}}, key, date) =
+    joinpath("wc2.1_2.5m_$(key)_$(_date2string(T, date)).tif")
+
+zipname(T::Type{<:WorldClim{Weather}}, key, decade) =
+    "wc2.1_2.5m_$(key)_$(WEATHER_DECADES[decade]).zip"
+
+zipurl(T::Type{<:WorldClim{Weather}}, key, decade) =
+    joinpath(WORLDCLIM_URL, "hist", zipname(T, key, decade))
+
+zippath(T::Type{<:WorldClim{Weather}}, key, decade) =
+    joinpath(rasterpath(T), "zips", zipname(T, key, decade))
+
+# Utils
+
+_dateformat(::Type{<:WorldClim}) = DateFormat("yyyy-mm")
+
+_filename2date(T::Type{<:WorldClim}, fn::AbstractString) =
+    _string2date(T, basename(fn)[findfirst(r"\d\d\d\d-\d\d", basename(fn))])

--- a/test/awap.jl
+++ b/test/awap.jl
@@ -1,0 +1,21 @@
+module SSLTestAWAP
+using SimpleSDMDataSources, Test, Dates
+
+using SimpleSDMDataSources: rastername, zipurl, zipname, zippath
+
+raster_file = joinpath(ENV["ECODATASOURCES_PATH"], "AWAP/vprp/vprph09/20010101.grid")
+@test rasterpath(AWAP, VapourPressure{H09}, Date(2001, 1)) == raster_file
+@test rastername(AWAP, VapourPressure{H09}, Date(2001, 1)) == "20010101.grid" 
+
+@test zipurl(AWAP, VapourPressure{H09}, Date(2001, 1)) ==
+    "http://www.bom.gov.au/web03/ncc/www/awap/vprp/vprph09/daily/grid/0.05/history/nat/2001010120010101.grid.Z"
+@test zippath(AWAP, VapourPressure{H09}, Date(2001, 1)) ==
+    joinpath(ENV["ECODATASOURCES_PATH"], "AWAP/vprp/vprph09/20010101.grid.Z")
+@test zipname(AWAP, VapourPressure{H09}, Date(2001, 1)) == "20010101.grid.Z"
+
+dates = DateTime(2001, 01, 01), DateTime(2001, 01, 02)
+download_raster(AWAP, VapourPressure{H09}; dates=dates)
+
+@test isfile(raster_file)
+
+end

--- a/test/worldclim-bioclim.jl
+++ b/test/worldclim-bioclim.jl
@@ -1,7 +1,16 @@
-module SSLTestWorldClim
+module SSLTestWorldClimBioClim
 using SimpleSDMDataSources
 using Test
 
-download_raster(WorldClim, BioClim; layer=2, resolution=10.0)
+using SimpleSDMDataSources: rastername, zipurl, zipname, zippath
+
+zip_file = "https://biogeo.ucdavis.edu/data/worldclim/v2.1/base/wc2.1_10m_bio.zip"
+@test zipurl(WorldClim{BioClim}, 2, 10.0) == zip_file
+@test zipname(WorldClim{BioClim}, 2, 10.0) == "wc2.1_10m_bio.zip"
+
+raster_file = joinpath(ENV["ECODATASOURCES_PATH"], "WorldClim/BioClim/wc2.1_10m_bio_2.tif")
+@test rasterpath(WorldClim{BioClim}, 2, 10.0) == raster_file
+@test download_raster(WorldClim{BioClim}; layer=2, resolution=10.0) == raster_file
+@test isfile(raster_file)
 
 end

--- a/test/worldclim-weather.jl
+++ b/test/worldclim-weather.jl
@@ -1,0 +1,22 @@
+module SSLTestWorldClimWeather
+using SimpleSDMDataSources, Test, Dates
+
+using SimpleSDMDataSources: rastername, zipurl, zipname, zippath
+
+raster_file = joinpath(ENV["ECODATASOURCES_PATH"], "WorldClim/Weather/prec/wc2.1_2.5m_prec_2001-01.tif")
+@test rasterpath(WorldClim{Weather}, :prec, Date(2001, 1)) == raster_file
+@test rastername(WorldClim{Weather}, :prec, Date(2001, 1)) == "wc2.1_2.5m_prec_2001-01.tif"
+
+
+zip_file = joinpath(ENV["ECODATASOURCES_PATH"], "WorldClim/Weather/zips/wc2.1_2.5m_prec_2010-2018.zip")
+@test zippath(WorldClim{Weather}, :prec, Date(2010)) == zip_file
+@test zipurl(WorldClim{Weather}, :prec, Date(2010)) == 
+    "https://biogeo.ucdavis.edu/data/worldclim/v2.1/hist/wc2.1_2.5m_prec_2010-2018.zip"
+@test zipname(WorldClim{Weather}, :prec, Date(2010)) == 
+    "wc2.1_2.5m_prec_2010-2018.zip"
+
+# These files are 3GB each. Probably too big to test in CI.
+# Not sure what to do about that.
+# download_raster(WorldClim{Weather}, :prec, Date(2001):Month(1):Date(2001, 12))
+
+end


### PR DESCRIPTION
This PR adds a number of datasets with multiple files in a time-sequence: AWAP, ALWB, WorldClim Weather.

There are some experiments with how to do this cleanly - ALWB and AWAP use types to specify layers, as especially with ALWB there are a lot of variants. All datasets take a `dates` argument which can be a range or a tuple of the end points. In WorldClim multiple dates use the same zip file, which are by decades.

It's not clear what should be returned when multiple dates and layers are downloaded together.

There are also a number of common methods added like `rasterpath` witch can give the base folder path, dataset paths and specific file paths - this is really useful for loading files in GeoData.jl.

I've used an `ENV` var to allow setting the assets path, but his is just one of many ways we could do this.

ALWB is not quite working yet, but the others should be. Some tests are included.
